### PR TITLE
Fixed deprecasion warning

### DIFF
--- a/Find.pm
+++ b/Find.pm
@@ -179,7 +179,7 @@ sub _find(*) {
     my $dir = File::Spec->catdir(split(/::/, $category));
 
     my @dirs;
-    if (defined @Module::Find::ModuleDirs) {
+    if (@Module::Find::ModuleDirs) {
         @dirs = map { File::Spec->catdir($_, $dir) }
             @Module::Find::ModuleDirs;
     } else {


### PR DESCRIPTION
defined(@array) is deprecated at /usr/local/lib/perl5/site_perl/5.16.0/Module/Find.pm line 182.
        (Maybe you should just omit the defined()?)
