### PR TITLE
Align package name parsing with how perl does it

### DIFF
--- a/Find.pm
+++ b/Find.pm
@@ -180,7 +180,7 @@ sub _find(*) {
     my ($category) = @_;
     return undef unless defined $category;
 
-    my $dir = File::Spec->catdir(split(/::/, $category));
+    my $dir = File::Spec->catdir(split(/::|'/, $category));
 
     my @dirs;
     if (@Module::Find::ModuleDirs) {
@@ -206,7 +206,7 @@ sub _find(*) {
     @results = map "$category\::$_", @results;
 
     @results = map {
-         ($_ =~ m{^(\w+(?:::\w+)*)$})[0] || die "$_ does not look like a package name"
+         ($_ =~ m{^(\w+(?:(?:::|')\w+)*)$})[0] || die "$_ does not look like a package name"
     } @results;
 
     return @results;

--- a/t/2-find.t
+++ b/t/2-find.t
@@ -1,4 +1,4 @@
-use Test::More tests => 5;
+use Test::More tests => 7;
 
 use Module::Find;
 
@@ -17,6 +17,8 @@ ok($#l == 1);
 ok($l[0] eq 'ModuleFindTest::SubMod');
 ok($l[1] eq 'ModuleFindTest::SubMod::SubSubMod');
 
-
+@l = findallmod "ModuleFindTest'SubMod";
+is($#l, 0, 'Found one module');
+is($l[0], "ModuleFindTest'SubMod::SubSubMod");
 
 


### PR DESCRIPTION
This is a relatively obscure perl feature:
"use Test'More;" works just the same as "use Test::More".

This patch allows a single quote as package separator.