### PR TITLE
support INC hooks with ->files

### DIFF
--- a/Find.pm
+++ b/Find.pm
@@ -182,21 +182,26 @@ sub _find(*) {
 
     my $dir = File::Spec->catdir(split(/::|'/, $category));
 
-    my @dirs;
-    if (@Module::Find::ModuleDirs) {
-        @dirs = map { File::Spec->catdir($_, $dir) }
-            @Module::Find::ModuleDirs;
-    } else {
-        @dirs = map { File::Spec->catdir($_, $dir) } @INC;
-    }
     @results = ();
 
-    foreach $basedir (@dirs) {
-        	next unless -d $basedir;
-    	
-        find({wanted   => \&_wanted,
-              no_chdir => 1,
-              follow   => $followMode}, $basedir);
+    foreach my $inc (@Module::Find::ModuleDirs ? @Module::Find::ModuleDirs : @INC) {
+        if (ref $inc) {
+            if (my @files = eval { $inc->files }) {
+                push @results,
+                    map { s/^\Q$category\E::// ? $_ : () }
+                    map { s{/}{::}g; s{\.pm$}{}; $_ }
+                    grep { /\.pm$/ }
+                    @files;
+            }
+        }
+        else {
+            my $basedir = File::Spec->catdir($inc, $dir);
+
+            next unless -d $basedir;
+            find({wanted   => \&_wanted,
+                  no_chdir => 1,
+                  follow   => $followMode}, $basedir);
+        }
     }
 
     # filter duplicate modules

--- a/t/inc-hook.t
+++ b/t/inc-hook.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+use Module::Find;
+
+BEGIN {
+  package MFTestIncHook;
+  sub files { keys %{$_[0]} };
+
+  sub MFTestIncHook::INC {
+    if (my $fat = $_[0]{$_[1]}) {
+      open my $fh, '<', \$fat
+        or die "error: $!";
+      return $fh;
+    }
+    return;
+  };
+
+  unshift @INC, bless {
+    'MFTest/Packed/Module.pm' => <<'END_MOD',
+package MFTest::Packed::Module;
+$VERSION = 5;
+END_MOD
+  }, __PACKAGE__;
+}
+
+my @l = useall 'MFTest::Packed';
+
+is scalar @l, 1;
+is $l[0], 'MFTest::Packed::Module';
+is $MFTest::Packed::Module::VERSION, 5;


### PR DESCRIPTION
In addition to directories, `@INC` can contain hooks, as described in [perlfunc](http://perldoc.perl.org/functions/require.html).  These hooks are able to provide arbitrary files.  This PR will use a method `files` to get a list of files that the hook can provide.  This is a convention established by App::FatPacker and Module::Pluggable.
